### PR TITLE
Mini-fix: extraneous warning reaction on messages starting with "??"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fixed ditto marks (") appearing in the ae7q call command.
 - Fixed issue where incorrect table was parsed in ae7q call command.
+- Fixed warning emoji reaction on messages starting with "??".
 
 
 ## [2.1.0] - 2020-01-04

--- a/main.py
+++ b/main.py
@@ -164,8 +164,11 @@ async def on_command_error(ctx: commands.Context, err: commands.CommandError):
     if isinstance(err, commands.UserInputError):
         await cmn.add_react(ctx.message, cmn.emojis.warning)
         await ctx.send_help(ctx.command)
-    elif isinstance(err, commands.CommandNotFound) and not ctx.invoked_with.startswith("?"):
-        await cmn.add_react(ctx.message, cmn.emojis.question)
+    elif isinstance(err, commands.CommandNotFound):
+        if ctx.invoked_with.startswith(("?", "!")):
+            return
+        else:
+            await cmn.add_react(ctx.message, cmn.emojis.question)
     elif isinstance(err, commands.CheckFailure):
         # Add handling of other subclasses of CheckFailure as needed.
         if isinstance(err, commands.NotOwner):


### PR DESCRIPTION
- also taken care of: "?!"